### PR TITLE
Task show page shows static map of the task's location now.

### DIFF
--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -15,3 +15,8 @@
         <strong>Delete</strong>
     <% end %>
 <% end %>
+
+<!-- <p>Coordinates: <%= @task.latitude %> <%= @task.longitude %></p> -->
+<br><br>
+<%= image_tag "http://maps.googleapis.com/maps/api/staticmap?center=#{@task.latitude},#{@task.longitude}&markers=#{@task.latitude},#{@task.longitude}&zoom=7&size=640x400",
+              class: 'img-fluid img-rounded'%>


### PR DESCRIPTION
Using static maps since they're less buggy. Keep main page's map as a dynamic one.